### PR TITLE
fix(sec): upgrade org.hibernate:hibernate-validator to 6.0.19.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <kubernetes-client.version>2.2.0</kubernetes-client.version>
         <mockwebserver.version>0.0.12</mockwebserver.version>
         <lombok.version>1.16.10</lombok.version>
-        <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.1.3.Final</hibernate-validator.version>
         <servlet-api.version>2.5</servlet-api.version>
         <spock.version>1.1-groovy-2.4-rc-3</spock.version>
         <spring-boot.version>1.5.1.RELEASE</spring-boot.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.hibernate:hibernate-validator 5.2.4.Final
- [CVE-2019-10219](https://www.oscs1024.com/hd/CVE-2019-10219)


### What did I do？
Upgrade org.hibernate:hibernate-validator from 5.2.4.Final to 6.0.19.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS